### PR TITLE
Update upload/download actions to v4 to address Node 16 deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Visual Studio cache/options directory
+.vs/

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ runs:
   using: composite
   steps:
     - name: Download continue file if exists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       continue-on-error: true
       with:
         name: ${{ inputs.RUN_NAME }}
@@ -37,7 +37,7 @@ runs:
         fi
       shell: bash
     - name: Upload continue file
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.RUN_NAME }}
         path: continue.txt


### PR DESCRIPTION
There's still an issue with Actions-R-Us/actions-tagger not being updated to Node 20, (see https://github.com/Actions-R-Us/actions-tagger/issues/90), and we may have to fork that if the maintainer never gets around to releasing it.